### PR TITLE
fix: EditorForm class only adds tags as choices when it is created

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+django = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.9"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,52 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "c36ae28fea7b9a4cc02145632e2f41469af2e7b38b801903abb8333d3306f36b"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "asgiref": {
+            "hashes": [
+                "sha256:4ef1ab46b484e3c706329cedeff284a5d40824200638503f5768edb6de7d58e9",
+                "sha256:ffc141aa908e6f175673e7b1b3b7af4fdb0ecb738fc5c8b88f69f055c2415214"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.1"
+        },
+        "django": {
+            "hashes": [
+                "sha256:51284300f1522ffcdb07ccbdf676a307c6678659e1284f0618e5a774127a6a08",
+                "sha256:e22c9266da3eec7827737cde57694d7db801fedac938d252bf27377cec06ed1b"
+            ],
+            "index": "pypi",
+            "version": "==3.2.9"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c",
+                "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"
+            ],
+            "version": "==2021.3"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae",
+                "sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==0.4.2"
+        }
+    },
+    "develop": {}
+}

--- a/mysite/t4t/forms.py
+++ b/mysite/t4t/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.db.utils import OperationalError
 from .models import Tag
 
 class EditorForm(forms.Form):
@@ -6,6 +7,11 @@ class EditorForm(forms.Form):
     img_link = forms.URLField(required=True)
     body = forms.CharField(widget=forms.Textarea, required=True)
     choices = []
-    for tag in Tag.objects.all():
-        choices.append((tag.tag_id, tag.name))
-    tags = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=choices, required=True)
+
+    def __init__(self):
+        try:
+            for tag in Tag.objects.all():
+                self.choices.append((tag.tag_id, tag.name))
+            tags = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=self.choices, required=True)
+        except OperationalError:
+            pass


### PR DESCRIPTION
The error with a table not being found is because importing the `forms.py` file runs a loop over all tags, but if the app hasn't ran yet, that table will not exist yet. Instead, it should be in the `__init__` method, so that when a new `EditorForm` is created it will add the tags at that point instead.

Also, in case there are no tags, there is a `try except` block to ignore the error. This means that tags need to be added before this form is used, otherwise no tags will show up.