### PR TITLE
Added form to skills page

### DIFF
--- a/mysite/t4t/forms.py
+++ b/mysite/t4t/forms.py
@@ -6,15 +6,6 @@ from .models import Tag, Comment
 class EditorForm(forms.Form):
     title = forms.CharField(max_length=255, required=True)
     body = forms.CharField(widget=forms.Textarea, required=True)
-    choices = []
-
-    def __init__(self):
-        try:
-            for tag in Tag.objects.all():
-                self.choices.append((tag.tag_id, tag.name))
-            tag = forms.MultipleChoiceField(widget=forms.CheckboxSelectMultiple, choices=self.choices, required=True)
-        except OperationalError:
-            pass
 
 class CommentForm(forms.ModelForm):
     class Meta:

--- a/mysite/t4t/templates/skills.html
+++ b/mysite/t4t/templates/skills.html
@@ -8,7 +8,16 @@
 
 <a href="{% url 'post_detail' post.post_id %} ">Read More</a>
 {% endfor %}
+<br><br>
+<!-- NEED TO FIX URL FOR FORM ACTION - The #1 needs to
+be replaced with something dynamic and not static -->
+<form action="{% url 'skillspage' 1 %}" method="POST">
+    {% csrf_token %} 
+    {{ form }}
+    <input type="submit" name="create" value="Create" />
+</form>
 
+<br><br><br><br><br><br>
 <a href="{% url 'home' %} ">Homepage</a>
 
 <a href="{% url 'categorypage' %} ">Categories Page</a>

--- a/mysite/t4t/templates/skills.html
+++ b/mysite/t4t/templates/skills.html
@@ -9,9 +9,8 @@
 <a href="{% url 'post_detail' post.post_id %} ">Read More</a>
 {% endfor %}
 <br><br>
-<!-- NEED TO FIX URL FOR FORM ACTION - The #1 needs to
-be replaced with something dynamic and not static -->
-<form action="{% url 'skillspage' 1 %}" method="POST">
+
+<form action="{% url 'skillspage' category.category_id %}" method="POST">
     {% csrf_token %} 
     {{ form }}
     <input type="submit" name="create" value="Create" />

--- a/mysite/t4t/views.py
+++ b/mysite/t4t/views.py
@@ -14,9 +14,25 @@ def categorypage(request):
 
 def skillspage(request, category_id):
     # get QuerySet object containing posts in descending order of post_id
-    posts = Post.objects.all().order_by('-post_id')
     category = Category.objects.get(pk=category_id)
-    return render(request=request, template_name='skills.html', context={ 'posts': posts, 'category':category })
+    posts = Post.objects.all().order_by('-post_id')
+###   NEED TO FILTER BY CATEGORY_ID    ### 
+    if request.method == 'GET':
+        form = EditorForm()
+        return render(request=request, template_name='skills.html', context={ 'form': form, "posts": posts, "category":category })
+    if request.method == 'POST':    
+        # capture POST data as EditorForm instance
+        form = EditorForm(request.POST)
+        # validate form
+        if form.is_valid():
+            title = form.cleaned_data['title']
+            body = form.cleaned_data['body']
+            #tags = form.cleaned_data['tags']
+            post = Post.objects.create(title=title, body=body, category=category)
+            post.save()
+            #post.tags.set(tags) 
+### GET REDIRECT TO REFRESH SKILLS PAGE INSTEAD OF GOING TO HOME ###
+        return HttpResponseRedirect(reverse('home'))
 
 def edit(request, post_id):
     if request.method == 'GET':

--- a/mysite/t4t/views.py
+++ b/mysite/t4t/views.py
@@ -1,3 +1,4 @@
+from django.db.models.fields.related import ForeignKey
 from django.shortcuts import render, redirect
 from django.http import HttpResponseRedirect
 from django.urls import reverse
@@ -15,7 +16,7 @@ def categorypage(request):
 def skillspage(request, category_id):
     # get QuerySet object containing posts in descending order of post_id
     category = Category.objects.get(pk=category_id)
-    posts = Post.objects.all().order_by('-post_id')
+    posts = Post.objects.filter(category=category_id).order_by('-post_id')
 ###   NEED TO FILTER BY CATEGORY_ID    ### 
     if request.method == 'GET':
         form = EditorForm()
@@ -31,19 +32,19 @@ def skillspage(request, category_id):
             post = Post.objects.create(title=title, body=body, category=category)
             post.save()
             #post.tags.set(tags) 
-### GET REDIRECT TO REFRESH SKILLS PAGE INSTEAD OF GOING TO HOME ###
-        return HttpResponseRedirect(reverse('home'))
+
+        return redirect('skillspage', category_id=category.category_id)
 
 def edit(request, post_id):
     if request.method == 'GET':
         # get Post object by its post_id
         post = Post.objects.get(pk=post_id)
         # get a list of tag_id from ManyRelatedManager object
-        tags = []
-        for tag in post.tags.all():
-            tags.append(tag.tag_id)
+        # tags = []
+        # for tag in post.tags.all():
+        #     tags.append(tag.tag_id)
         # pre-populate form with values of the post
-        form = EditorForm(initial={ 'title': post.title, 'body': post.body, 'tags': tags})
+        form = EditorForm(initial={ 'title': post.title, 'body': post.body})
         return render(request=request, template_name='edit.html', context={ 'form': form, 'id': post_id })
     if request.method == 'POST':    
         # capture POST data as EditorForm instance


### PR DESCRIPTION
I went to Office Hours last night and reviewed our app with Brandon

1. Read the commented out section in caps in Skills.html. For now the form action url has "1" in it. That is hardcoded and needs to be changed to be dynamic.
2. I cleaned up the forms.py to get rid of any img link
3. In Views.py under skills page, below where it says posts = Post.objects.all.......
         a) We need to filter the posts by category id so that only posts for each skill show on that 
         page instead of showing up on each skill page
         b) For now I commented out all tags as without tags the site breaks
         c) We need to fix the redirect to the skills page but I can only get it to return to the home page
